### PR TITLE
Modify to work with snap-0.10

### DIFF
--- a/snaplet-mongodb-minimalistic.cabal
+++ b/snaplet-mongodb-minimalistic.cabal
@@ -33,8 +33,9 @@ Library
 
   Build-depends:
     base                        == 4.*,
+    lens                        == 3.7.*,
     mtl                         == 2.*,
-    snap                        == 0.9.*,
+    snap                        == 0.10.*,
     snap-core                   == 0.9.*,
     text                        == 0.11.*,
     mongoDB                     == 1.3.*

--- a/src/Snap/Snaplet/MongoDB/Functions/S.hs
+++ b/src/Snap/Snaplet/MongoDB/Functions/S.hs
@@ -17,7 +17,6 @@ module Snap.Snaplet.MongoDB.Functions.S
 import           Control.Monad.Error (runErrorT)
 
 import           Snap (MonadIO, MonadState, gets, liftIO) -- transformers, mtl
-import           Snap (Lens, getL) -- data-lens
 import           Snap (Snaplet, snapletValue)
 import           Snap.Snaplet.MongoDB.Core
 


### PR DESCRIPTION
Two notes:
- Personally, I don't think the direct dependency on the lens package is a big deal,
  since snap already depends on lens. But it could be avoided pretty easily, at the
  cost of somewhat uglier code.
- This compiles, it's straightforward, and it looks right to me. But I haven't tested
  it otherwise.

snap-0.10 uses the lens package instead of data-lens, so we use
lens package lenses in M.hs. Also remove some unnecessary imports
in S.hs, bump the snap dependency, and add a direct dependency on
the lens package. (The last is needed because we're using functions
from Control.Lens that Snap does not re-export.)
