### PR TITLE
Bump snap dependency to include 0.11

### DIFF
--- a/snaplet-mongodb-minimalistic.cabal
+++ b/snaplet-mongodb-minimalistic.cabal
@@ -1,5 +1,5 @@
 Name:               snaplet-mongodb-minimalistic
-Version:            0.0.6.6
+Version:            0.0.6.7
 Synopsis:           Minimalistic MongoDB Snaplet.
 Description:        Minimalistic MongoDB Snaplet.
 License:            BSD3
@@ -35,7 +35,7 @@ Library
     base                        == 4.*,
     lens                        == 3.7.*,
     mtl                         == 2.*,
-    snap                        == 0.10.*,
+    snap                        >= 0.10 && < 0.11,
     snap-core                   == 0.9.*,
     text                        == 0.11.*,
     mongoDB                     == 1.3.*


### PR DESCRIPTION
Builds for me with the relaxed upper bound. snap-0.11 is mostly dependency-bound changes itself.
