### PR TITLE
Relaxed cabal constrains to allow installation with Snap 0.12

### DIFF
--- a/snaplet-mongodb-minimalistic.cabal
+++ b/snaplet-mongodb-minimalistic.cabal
@@ -1,5 +1,5 @@
 Name:               snaplet-mongodb-minimalistic
-Version:            0.0.6.8
+Version:            0.0.6.9
 Synopsis:           Minimalistic MongoDB Snaplet.
 Description:        Minimalistic MongoDB Snaplet.
 License:            BSD3
@@ -33,10 +33,10 @@ Library
 
   Build-depends:
     base                        >= 4 && < 5,
-    lens                        >= 3.7 && < 3.9,
+    lens                        >= 3.7 && < 3.10,
     mtl                         >= 2.0 && < 2.2,
     transformers                >= 0.2 && < 0.4,
-    snap                        >= 0.11 && < 0.12,
+    snap                        >= 0.11 && < 0.13,
     text                        >= 0.11 && < 0.12,
     mongoDB                     >= 1.3 && < 1.4
 


### PR DESCRIPTION
Now that Snap 0.12 is out, we need to dump our cabal constrains accordingly.
