### PR TITLE
Updated lens maximum version to 3.11

### DIFF
--- a/snaplet-mongodb-minimalistic.cabal
+++ b/snaplet-mongodb-minimalistic.cabal
@@ -1,5 +1,5 @@
 Name:               snaplet-mongodb-minimalistic
-Version:            0.0.6.10
+Version:            0.0.6.11
 Synopsis:           Minimalistic MongoDB Snaplet.
 Description:        Minimalistic MongoDB Snaplet.
 License:            BSD3
@@ -33,7 +33,7 @@ Library
 
   Build-depends:
     base                        >= 4 && < 5,
-    lens                        >= 3.7 && < 3.10,
+    lens                        >= 3.7 && < 3.11,
     mtl                         >= 2.0 && < 2.2,
     transformers                >= 0.2 && < 0.4,
     snap                        >= 0.11 && < 0.13,


### PR DESCRIPTION
I updated the maximum lens version to 3.11. The current version of Snap uses version 3.10.1 and snaplet-mongodb-minimalistic cannot be added to it because of a version conflict. I built the new code and it compiles fine.
