### PR TITLE
Updated some dependencies to match stackage snapshot 6.27

### DIFF
--- a/snaplet-mongodb-minimalistic.cabal
+++ b/snaplet-mongodb-minimalistic.cabal
@@ -32,14 +32,14 @@ Library
 
   Other-modules:
 
-  Build-depends:
-    base                        >= 4 && < 5,
-    lens                        >= 3.7 && < 3.11,
-    mtl                         >= 2.0 && < 2.2,
-    transformers                >= 0.2 && < 0.4,
-    snap                        >= 0.11 && < 0.14,
-    text                        >= 0.11 && < 1.2,
-    mongoDB                     >= 1.4 && < 1.5
+  Build-depends: base                >= 4 && < 5
+               , lens                >= 4.0 && < 5.0
+               , mtl                 >= 2.0 && < 2.3
+               , transformers        >= 0.2 && < 0.5
+               , snap                >= 0.11 && < 1.0
+               , text                >= 0.11 && < 1.3
+               , mongoDB             >= 2.0 && < 2.2
+               , resource-pool       >= 0.2 && < 0.4
 
   GHC-Options: -Wall
 

--- a/src/Snap/Snaplet/MongoDB/Core.hs
+++ b/src/Snap/Snaplet/MongoDB/Core.hs
@@ -14,7 +14,7 @@ module Snap.Snaplet.MongoDB.Core
 import           Data.Text (Text)
 import           Snap.Snaplet
 import           Control.Monad.IO.Class
-import           Database.MongoDB (Database, Host, Pipe, AccessMode (UnconfirmedWrites), close, connect)
+import           Database.MongoDB (Database, Host, Pipe, AccessMode (..), close, connect)
 import           Data.Pool (Pool, createPool)
 
 ------------------------------------------------------------------------------
@@ -70,7 +70,7 @@ mongoDBInit :: Int                      -- ^ Maximum pool size.
 mongoDBInit poolSize host database =
   makeSnaplet "snaplet-mongodb" description Nothing $ do
     pool <- liftIO $ createPool (connect host) close poolSize 0.5 1
-    return $ MongoDB pool database UnconfirmedWrites
+    return $ MongoDB pool database (ConfirmWrites [])
 
 ------------------------------------------------------------------------------
 -- | Initializer function.


### PR DESCRIPTION
I'm quite new to haskell so don't hesitate to point out any weirdness.

This PR only updates some dependencies, like mongoDB from 1.x to 2.x and adds the resource-pool package since mongoDB removed pools for itself. Mainly because I'm using the 6.27 lts stackage napshot and those are the dependencies I need

**disclaimer**: I haven't been able to test the example provided here but maybe I'll try it out tomorrow